### PR TITLE
Upgrade to lightning 106

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning = { version = "0.0.104", features = ["max_level_trace"] }
+lightning = { version = "0.0.106", features = ["max_level_trace"] }
 bdk = { git = "https://github.com/johncantrell97/bdk" }


### PR DESCRIPTION
Nothing remarkable. Just a version bump -- `cargo test` still compiles :) 